### PR TITLE
fix typos

### DIFF
--- a/Authent & Authorisation/exercice 1/README.md
+++ b/Authent & Authorisation/exercice 1/README.md
@@ -1,4 +1,4 @@
-This exercice aims to configure a ServiceAccount for Pods and accessing the API Server From a Pod
+This exercise aims to configure a ServiceAccount for Pods and accessing the API Server From a Pod
 
 A lot of applications that run in the cluster (read: running in Pods), need to communicate with the API server.
 For example, some applications might need to know:
@@ -94,7 +94,7 @@ What do you notice ?
 
 - A ServiceAccount is not that useful unless certain rights are bound to it. Defines a Role allowing to list all the Pods in the your namespace.
 
-What kind of Role do you need ? Role ou ClusterRole ?
+What kind of Role do you need ? Role or ClusterRole ?
 
 - Try to create the Role in your namespace with good rules and verify that it's created
 

--- a/Authent & Authorisation/exercice 2/README.md
+++ b/Authent & Authorisation/exercice 2/README.md
@@ -1,4 +1,4 @@
-This exercice aims to configure the cluster API server to use OpenIDConnect (OIDC) tokens for user authentication.
+This exercise aims to configure the cluster API server to use OpenIDConnect (OIDC) tokens for user authentication.
 
 As indicated in the following schema, Kubernetes does not perform the OIDC authentication flow of the end-user.
 It just validates the given tokens and eventually refresh them if needed.
@@ -44,7 +44,7 @@ Can you verify this ?
 
 - Try to list the nodes of the cluster using the new `oidc-user` user (option --user)
 
-- We can see that the user is getting authenticated but he needs authorization. For that, create a cluster role that can do everything in all k8s ressources.
+- We can see that the user is getting authenticated but he needs authorization. For that, create a cluster role that can do everything in all k8s resources.
 
 - Create a ClusterRoleBinding to attach the clusterRole to your user
 - Try to list the nodes of the cluster using the new user (option --user)

--- a/Core objects/Deployment/exercise-3/README.md
+++ b/Core objects/Deployment/exercise-3/README.md
@@ -8,7 +8,7 @@ You will see the interests of using deployment:
 
 ## Deploy version 1.0 with 2 replicas
 
-Create a deployment file with the following content (be carefull, the provided `.yaml` file may be incorrect! See [the documentation if needed](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deploymentspec-v1-apps)):
+Create a deployment file with the following content (be careful, the provided `.yaml` file may be incorrect! See [the documentation if needed](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deploymentspec-v1-apps)):
 ```
 apiVersion: apps/v1
 kind: Deployment

--- a/Core objects/PVC-PV/exercise-4/README.md
+++ b/Core objects/PVC-PV/exercise-4/README.md
@@ -29,7 +29,7 @@ spec:
       storage: 2Gi
 ```
 
-Declare the claim (be carefull, the provided `.yaml` file may be incorrect....)
+Declare the claim (be careful, the provided `.yaml` file may be incorrect....)
 ```sh
 kubectl apply -f pv-claim.yaml
 ```

--- a/Core objects/Pods/exercise-2/README.md
+++ b/Core objects/Pods/exercise-2/README.md
@@ -8,7 +8,7 @@ Then, you will add taints to all the workers and see the effect.
 You will be responsible for splitting up the worker nodes and making:
 * one of the worker nodes a production (prod) environment node.
 * one of the worker nodes a development (dev) environment node.
-* ONLY if you have a threee workder node cluster: one of the worker nodes a pre-production (iso) environment node.
+* ONLY if you have a three worker node cluster: one of the worker nodes a pre-production (iso) environment node.
 
 The purpose of identifying the production type is to not accidentally deploy pods into the production environment. You will use taints and tolerations to achieve this, and then you will deploy two pods: One pod will be scheduled to the dev environment, and one pod will be scheduled to the prod environment.
 
@@ -19,7 +19,7 @@ Get list nodes with current taints:
 kubectl get nodes  -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
 ```
 
-Deploy a pod which does not tolerate taints (be carefull, the provided `.yaml` file may be incorrect....)
+Deploy a pod which does not tolerate taints (be careful, the provided `.yaml` file may be incorrect....)
 ```sh
 kubectl apply -f no-toleration-pod.yml
 ```

--- a/Core objects/configMap&Secret/exercise-1/README.md
+++ b/Core objects/configMap&Secret/exercise-1/README.md
@@ -1,6 +1,6 @@
 # exercise-1: A secret and a configmap for a database.
 
-In this exercise, you will create a k8s secret as well as a k8s configmap to correctly configure a MariaDB databse.
+In this exercise, you will create a k8s secret as well as a k8s configmap to correctly configure a MariaDB database.
 
 # Secrets
 

--- a/Core objects/ingressController/exercise-6/README.md
+++ b/Core objects/ingressController/exercise-6/README.md
@@ -1,6 +1,6 @@
 # exercise-6: IngressRules
 
-In this exercise, you will create an application pod `/v1` and expose it through an Ingress targetting a Service.
+In this exercise, you will create an application pod `/v1` and expose it through an Ingress targeting a Service.
 
 
 Then you will create a second version of the application (`/v2`) and manage the routing via another Ingress.
@@ -32,7 +32,7 @@ spec:
     servicePort: 666
 ```
 
-Create the ingress. Be carefull, it may be incorrect regarding the service we want to target...
+Create the ingress. Be careful, it may be incorrect regarding the service we want to target...
 ```sh
 kubectl apply -f basic-ingress.yaml
 ```

--- a/Correction/Authent & Authorisation/exercice 1/README.md
+++ b/Correction/Authent & Authorisation/exercice 1/README.md
@@ -1,4 +1,4 @@
-This exercice aims to configure a ServiceAccount for Pods and accessing the API Server From a Pod
+This exercise aims to configure a ServiceAccount for Pods and accessing the API Server From a Pod
 
 A lot of applications that run in the cluster (read: running in Pods), need to communicate with the API server.
 For example, some applications might need to know:
@@ -176,7 +176,7 @@ serviceaccount/training-sa created
 
 - A ServiceAccount is not that useful unless certain rights are bound to it. Defines a Role allowing to list all the Pods in the your namespace.
 
-What kind of Role do you need ? Role ou ClusterRole ?
+What kind of Role do you need ? Role o ClusterRole ?
 > Role because, I just need to list all Pods in my namespace and not in others namespaces.
 
 

--- a/Correction/Authent & Authorisation/exercice 2/README.md
+++ b/Correction/Authent & Authorisation/exercice 2/README.md
@@ -1,4 +1,4 @@
-This exercice aims to configure the cluster API server to use OpenIDConnect (OIDC) tokens for user authentication.
+This exercise aims to configure the cluster API server to use OpenIDConnect (OIDC) tokens for user authentication.
 
 As indicated in the following schema, Kubernetes does not perform the OIDC authentication flow of the end-user.
 It just validates the given tokens and eventually refresh them if needed.
@@ -51,7 +51,7 @@ $ less .kube/config
 ```sh
 $ kubectl --user=<user@wescale.fr> get nodes
 ```
-- Now we can see that the user is getting authenticated, now it needs authorization. For that, we need to create a cluster role that can do everything in all k8s ressources.
+- Now we can see that the user is getting authenticated, now it needs authorization. For that, we need to create a cluster role that can do everything in all k8s resources.
 
 ```sh
 $ kubectl create -f clusterRole.yml

--- a/Correction/Helm/exercice 2/README.md
+++ b/Correction/Helm/exercice 2/README.md
@@ -14,7 +14,7 @@ We put the Image repository and container ports for both backend and frontend. A
 
 - deployment.yaml
 
-We can create our template for deployment in templates/deployment.yaml. This template will be used to generate both backend-deployment.yamland frontend-deployment.yaml
+We can create our template for deployment in templates/deployment.yaml. This template will be used to generate both backend-deployment.yam land frontend-deployment.yaml
 
 - service.yaml
 This template will be used to generate both backend-service.yaml and frontend-service.yaml 

--- a/GitOps/README.md
+++ b/GitOps/README.md
@@ -1,4 +1,4 @@
-In this exercise, you will instanciate an ArgoCD and get familiar with basics of GitOps.
+In this exercise, you will instantiate an ArgoCD and get familiar with basics of GitOps.
 
 
 ## Install ArgoCD
@@ -38,7 +38,7 @@ You should see your application.
 
 # Declarative manifests
 
-Look at the resources your kubernets cluster can manage (`kubectl api-resources`).
+Look at the resources your kubernetes cluster can manage (`kubectl api-resources`).
 What are the resources provided by **argo**?
 
 Edit the `application.yaml` to declare an ArgoCD application named `declarative-gitops-chart` to deploy the same Helm chart as above.

--- a/Istio/README.md
+++ b/Istio/README.md
@@ -20,7 +20,7 @@ istiod-66bb7cb55c-59cvh                 1/1     Running   0          75s
 ```
 
 ## HTTP routing with istio
-We will deploy ngninx and apache in the cluster and use Istio traffic management to reach those services
+We will deploy nginx and apache in the cluster and use Istio traffic management to reach those services
 
 First we will create a namespace called "mesh" and add the appropriate label to enable envoy sidecar injection
 ```sh
@@ -91,11 +91,11 @@ Then we create a VirtualService and DestinationRule to achieve canary deployment
 ```sh
 kubectl apply -f web-dr-vs-canary.yaml -n mesh
 ```
-The virtual service routes trafic based on host header, to test the canary release execute several times:
+The virtual service routes traffic based on host header, to test the canary release execute several times:
 ```sh
 curl --header "Host: hello.wescale.fr" http://$INGRESS_HOST:$INGRESS_PORT/
 ```
-90% of trafic is going to version 1 and the remaining 10% is going to version 2
+90% of traffic is going to version 1 and the remaining 10% is going to version 2
 
 ## Observability
 
@@ -117,13 +117,13 @@ Deploy bookinfo VirtualService
 kubectl apply -f bookinfo-vs.yaml -n mesh
 ```
 
-Generate trafic 
+Generate traffic 
 ```sh
 watch -n 1 curl -o /dev/null -s -w %{http_code} http://$INGRESS_HOST:$INGRESS_PORT/productpage
 ```
 
 
-Visualise trafic graph with kiali (replace x with your trainee index)
+Visualize traffic graph with kiali (replace x with your trainee index)
 
 http://lb.wsc-kubernetes-adv-training-x.wescaletraining.fr:30672/kiali/console/graph/namespaces/?edges=responseTime&graphType=versionedApp&unusedNodes=false&operationNodes=false&injectServiceNodes=true&duration=60&refresh=10000&namespaces=mesh&layout=dagre
 

--- a/Operators/README.md
+++ b/Operators/README.md
@@ -1,6 +1,6 @@
 # Hands-on: Operators
 
-During this exercice we will install a mysql operator to create mysql cluster and manage backups to minio S3 bucket
+During this exercise we will install a mysql operator to create mysql cluster and manage backups to minio S3 bucket
 https://github.com/bitpoke/mysql-operator
 
 ## Installing Mysql Operator
@@ -21,7 +21,7 @@ NAME               READY   STATUS    RESTARTS   AGE
 mysql-operator-0   2/2     Running   0          41s
 ```
 
-The operator extended K8S api server with 2 new api ressources
+The operator extended K8S api server with 2 new api resources
 
 ```sh
 kubectl get crd | grep "presslabs"
@@ -37,7 +37,7 @@ First we will create a secret containing the root password
 kubectl apply -f root-secret.yaml
 ```
 
-Then we will deploy the ressource MysqlCluster to create the database cluster
+Then we will deploy the resource MysqlCluster to create the database cluster
 
 ```sh
 kubectl apply -f cluster.yaml

--- a/ResourceManagement/Exercise-6/README.md
+++ b/ResourceManagement/Exercise-6/README.md
@@ -10,7 +10,7 @@ Then, you will create 3 pods, each with or without requests and limits.
 kubectl create namespace default-resources-config
 ```
 
-## Create a LimitRange to specifiy default limits and requests
+## Create a LimitRange to specify default limits and requests
 
 ```
 apiVersion: v1

--- a/ResourceManagement/Exercise-7/README.md
+++ b/ResourceManagement/Exercise-7/README.md
@@ -1,7 +1,7 @@
 # exercise-7: Limits per container and inside a namespace
 
-In this exercise, you will see how to control the maximum resource used in a namspace:
-* LimitRange to defing limits per container
+In this exercise, you will see how to control the maximum resource used in a namespace:
+* LimitRange to defining limits per container
 * ResourceQuota to define limits inside the whole namespace
 
 ## Start by creating a namespace
@@ -43,12 +43,12 @@ kubectl get pod resource-constraints-pod --namespace resource-constraints-demo -
 
 Are the values matching the ones we expected?
 
-## Create pod outside the boudaries of the LimitRange
+## Create pod outside the boundaries of the LimitRange
 ```sh
 kubectl create -f resource-constraints-pod-2.yaml --namespace resource-constraints-demo
 ```
 
-## Creata a new namespace 
+## Create a new namespace 
 
 ```sh
 kubectl create namespace resource-quota-demo

--- a/Scheduling/exercise-2/README.md
+++ b/Scheduling/exercise-2/README.md
@@ -8,7 +8,7 @@ Then, you will add taints to all the workers and see the effect.
 You will be responsible for splitting up the worker nodes and making:
 * one of the worker nodes a production (prod) environment node.
 * one of the worker nodes a development (dev) environment node.
-* ONLY if you have a threee workder node cluster: one of the worker nodes a pre-production (iso) environment node.
+* ONLY if you have a three worker node cluster: one of the worker nodes a pre-production (iso) environment node.
 
 The purpose of identifying the production type is to not accidentally deploy pods into the production environment. You will use taints and tolerations to achieve this, and then you will deploy two pods: One pod will be scheduled to the dev environment, and one pod will be scheduled to the prod environment.
 
@@ -19,7 +19,7 @@ Get list nodes with current taints:
 kubectl get nodes  -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
 ```
 
-Deploy a pod which does not tolerate taints (be carefull, the provided `.yaml` file may be incorrect....)
+Deploy a pod which does not tolerate taints (be careful, the provided `.yaml` file may be incorrect....)
 ```sh
 kubectl apply -f no-toleration-pod.yml
 ```

--- a/Troubleshooting/README.md
+++ b/Troubleshooting/README.md
@@ -16,4 +16,4 @@ Invalid image
 
 ### Plus service qui a un mauvais selector
 
-## plus de capacités -> eviction ou scheduled never ou limitRange
+## plus de capacités -> eviction or scheduled never or limitRange

--- a/deployment_strategies/exercise-5/README.md
+++ b/deployment_strategies/exercise-5/README.md
@@ -6,7 +6,7 @@ After performing a rolling update to the version *v1.1*, you will do a rollback 
 
 ## Deploy the version v1
 
-Complete the provided `deployment-v1.0.yaml` file to in dicate the deployment strategy:
+Complete the provided `deployment-v1.0.yaml` file to in dictate the deployment strategy:
 ```
 strategy:
     type: RollingUpdate
@@ -20,7 +20,7 @@ Then create the deployment:
 kubectl apply -f deployment-v1.0.yaml
 ```
 
-## Ensure everythin is fine
+## Ensure everything is fine
 
 ```sh
 kubectl get deployments
@@ -36,7 +36,7 @@ kubectl expose deployment kdemo-dep \
 --port=80 \
 --target-port=8080
 ```
-ou 
+or 
 ```
 kubectl create -f service.yaml
 ```
@@ -54,7 +54,7 @@ kubectl apply -f deployment-v1.1.yaml
 watch kubectl get pods -o wide
 ```
 
-Verify you get a new version of the website in your broser.
+Verify you get a new version of the website in your browser.
 
 ## RollBack to v1.0
 ```sh

--- a/install-your-cluster/README.md
+++ b/install-your-cluster/README.md
@@ -49,7 +49,7 @@ kubectl cluster-info
 
 ## Rotate the certificates
 
-Kubernetes involves a lot of certificates, which must be rotated in the case of a comprimised cert or just because they will soon expire.
+Kubernetes involves a lot of certificates, which must be rotated in the case of a compromised cert or just because they will soon expire.
 
 RKE provides useful commands to rotate certificates.
 
@@ -188,7 +188,7 @@ ps -ef|grep kube-controller
 
 Inspect the `cluster.yaml` file to determine the network plugin used by the cluster.
 
-Generally, netwok plugin are configured using Custom Resource Definition - CRDs. Those CRDs are additional Kubernetes objects. 
+Generally, network plugin are configured using Custom Resource Definition - CRDs. Those CRDs are additional Kubernetes objects. 
 To list the available resources on a cluster: `kubectl api-resources`
 ### Overlay network. 
 
@@ -196,5 +196,5 @@ As seen, Calico is able to integrate or not overlays (IpInIP or VxLAN).
 
 In the `kube-system` namespace, look at the `ippools` and `configmap/calico-config` objects. 
 
-* Is there an ovelay network?
+* Is there an overlay network?
 * Is BGP (BIRD) used?

--- a/monitoring/exercise-1/README.md
+++ b/monitoring/exercise-1/README.md
@@ -101,7 +101,7 @@ Create the deployment and service:
 kubectl create -f deployment.yaml
 ```
 
-Create the ServiceMonitor which targets the created abovce service:
+Create the ServiceMonitor which targets the created above service:
 ```
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
Using https://github.com/tbroadley/github-spellcheck-cli  with whitelist:

```
namespace
https
org
jwt
kubernetes
serviceaccount
svc
api
wsc
namespaces
Kubernetes
oidc
plugin
yml
idp
kubectl
nginx
pv
Nginx
pre
yaml
cip
configmap
mariadb
dns
rolebinding
voila
frontend
backend
tpl
Frontend
tls
Namespace
jsonpath
simplefrontend
fullname
app
metadata
Backend
simplebackend
localhost
Istio
istio
apps
Kiali
Grafana
bookinfo
kiali
wescaletraining
dagre
grafana
datasource
productpage
srcns
srcwl
dstns
dstwl
mysql
minio
github
presslabs
Mysql
mysqlbackups
mysqlclusters
config
Kubeconfig
qui
appelle
interne
cherche
mauvais
autoscaler
webserver
Autoscaler
hpa
krew
kube
Healthcheck
rke
kubeconfig
etcd
admin
aks
wordpress
stderr
stdout
hostname
env
blog
init
username
mysqld
blackboxexporter
spod
backboxexporter
blackbox
Wordpress
```